### PR TITLE
Compute Shaders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ EXAMPLE_OUTPUTS = \
 	advanced/shader \
 	basics/shapes  \
 	basics/camera \
+	advanced/compute \
 
 
 $(EXAMPLE_OUTPUTS): %: examples/%.c RSGL.h

--- a/RSGL.h
+++ b/RSGL.h
@@ -1279,7 +1279,11 @@ void RSGL_freeFont(RSGL_font* font) { RFont_font_free(font); }
 
 void RSGL_setFont(RFont_font* font) {
     if (font == NULL) {
+
+#ifdef RSGL_DEBUG
         printf("RSGL_setFont : invalid font\n");
+#endif
+
         return;
     }
     

--- a/RSGL.h
+++ b/RSGL.h
@@ -284,10 +284,19 @@ typedef struct RSGL_RENDER_INFO {
     RSGL_mat4 matrix;
 } RSGL_RENDER_INFO; /* render data */
 
+/* used internally for RSGL_deleteProgram */
+typedef enum RSGL_shaderType {
+	RSGL_shaderTypeNone = 0,
+	RSGL_shaderTypeStandard = 1, /* standard vertex+fragment shader */
+	RSGL_shaderTypeCompute = 2,
+	RSGL_shaderTypeGeometry = 4, /* unimplemented as of now */
+} RSGL_shaderType;
+
 /* custom shader program */
 #ifndef RSGL_programInfo
 typedef struct RSGL_programInfo {
     u32 program;
+	 RSGL_shaderType type;
 } RSGL_programInfo;
 #endif
 
@@ -308,6 +317,12 @@ typedef struct RSGL_renderer {
     RSGL_texture (* createAtlas)(u32 atlasWidth, u32 atlasHeight);
     u8 (* resizeAtlas)(RSGL_texture* atlas, u32 newWidth, u32 newHeight);
     void (* bitmapToAtlas)(RSGL_texture atlas, u8* bitmap, float x, float y, float w, float h);
+
+#ifdef RSGL_USE_COMPUTE
+	 RSGL_programInfo (*createComputeProgram)(const char* CShaderCode);
+	 void (*dispatchComputeProgram)(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z);
+	 void (*bindComputeTexture)(u32 texture, u8 format);
+#endif
 } RSGL_renderer;
 
 RSGLDEF void RSGL_setRenderer(RSGL_renderer renderer);
@@ -403,6 +418,11 @@ RSGLDEF void RSGL_renderScissorEnd(void);
 RSGLDEF RSGL_programInfo RSGL_renderCreateProgram(const char* VShaderCode, const char* FShaderCode, const char* posName, const char* texName, const char* colorName);
 RSGLDEF void RSGL_renderDeleteProgram(RSGL_programInfo program);
 RSGLDEF void RSGL_renderSetShaderValue(u32 program, char* var, float value[], u8 len);
+
+#ifdef RSGL_USE_COMPUTE
+RSGLDEF RSGL_programInfo RSGL_renderCreateComputeProgram(const char *CShaderCode);
+RSGLDEF void RSGL_renderDispatchComputeProgram(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z);
+#endif
 
 /* these are RFont functions that also must be defined by the renderer
 
@@ -698,6 +718,16 @@ void RSGL_renderDeleteProgram(RSGL_programInfo program) { return RSGL_currentRen
 void RSGL_renderSetShaderValue(u32 program, char* var, float value[], u8 len) {
     return RSGL_currentRenderer.setShaderValue(program, var, value, len);
 }
+
+#ifdef RSGL_USE_COMPUTE
+RSGL_programInfo RSGL_renderCreateComputeProgram(const char* CShaderCode) {
+	return RSGL_currentRenderer.createComputeProgram(CShaderCode);
+}
+
+void RSGL_renderDispatchComputeProgram(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z) {
+	RSGL_currentRenderer.dispatchComputeProgram(program, groups_x, groups_y, groups_z);
+}
+#endif
 
 void RSGL_init(RSGL_area r, void* loader, RSGL_renderer renderer) {
     RSGL_setRenderer(renderer);

--- a/RSGL.h
+++ b/RSGL.h
@@ -138,6 +138,11 @@ typedef bool RSGL_bool;
 #define RSGL_texture size_t
 #endif
 
+// WebGL doesn't support compute shaders iirc so yeah
+#if defined(__EMSCRIPTEN__) && defined(RSGL_USE_COMPUTE)
+#undef RSGL_USE_COMPUTE
+#endif
+
 /* 
 *******
 RSGL_[shape]

--- a/RSGL.h
+++ b/RSGL.h
@@ -972,7 +972,7 @@ void RSGL_drawPolygonFEx(RSGL_rectF o, u32 sides, RSGL_pointF arc, RSGL_color c)
 
     RSGL_point3D center =  (RSGL_point3D){o.x + (o.w / 2.0f), o.y + (o.h / 2.0f), 0};
     
-    o = (RSGL_rectF){o.x, o.y, o.w / 2, o.h / 2};    
+o = (RSGL_rectF){o.x, o.y, o.w / 2, o.h / 2};    
     RSGL_mat4 matrix = RSGL_initDrawMatrix(center);
 
     float displacement = 360.0f / (float)sides;

--- a/RSGL.h
+++ b/RSGL.h
@@ -422,6 +422,7 @@ RSGLDEF void RSGL_renderSetShaderValue(u32 program, char* var, float value[], u8
 #ifdef RSGL_USE_COMPUTE
 RSGLDEF RSGL_programInfo RSGL_renderCreateComputeProgram(const char *CShaderCode);
 RSGLDEF void RSGL_renderDispatchComputeProgram(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z);
+RSGLDEF void RSGL_renderBindComputeTexture(u32 texture, u8 format);
 #endif
 
 /* these are RFont functions that also must be defined by the renderer
@@ -726,6 +727,10 @@ RSGL_programInfo RSGL_renderCreateComputeProgram(const char* CShaderCode) {
 
 void RSGL_renderDispatchComputeProgram(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z) {
 	RSGL_currentRenderer.dispatchComputeProgram(program, groups_x, groups_y, groups_z);
+}
+
+void RSGL_renderBindComputeTexture(u32 texture, u8 format) {
+	RSGL_currentRenderer.bindComputeTexture(texture, format);
 }
 #endif
 

--- a/RSGL_gl.h
+++ b/RSGL_gl.h
@@ -1,3 +1,4 @@
+#include <GL/glext.h>
 #ifndef RSGL_H
 #include "RSGL.h"
 #endif
@@ -41,6 +42,12 @@ RSGLDEF void RSGL_GL_setShaderValue(u32 program, char* var, float value[], u8 le
 RFont_texture RFont_GL_create_atlas(u32 atlasWidth, u32 atlasHeight);
 b8 RFont_GL_resize_atlas(RFont_texture* atlas, u32 newWidth, u32 newHeight);
 void RFont_GL_bitmap_to_atlas(RFont_texture atlas, u8* bitmap, float x, float y, float w, float h);
+
+#ifdef RSGL_USE_COMPUTE
+RSGLDEF RSGL_programInfo RSGL_GL_createComputeProgram(const char* CShaderCode);
+RSGLDEF void RSGL_GL_dispatchComputeProgram(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z);
+RSGLDEF void RSGL_GL_bindComputeTexture(u32 texture, u8 format);
+#endif
 
 #endif
 
@@ -159,6 +166,18 @@ glUniform2fPROC glUniform2fSRC = NULL;
 glUniform3fPROC glUniform3fSRC = NULL;
 glUniform4fPROC glUniform4fSRC = NULL;
 
+#ifdef RSGL_USE_COMPUTE
+typedef void (*glDispatchComputePROC)(GLuint x, GLuint y, GLuint z);
+glDispatchComputePROC glDispatchComputeSRC = NULL;
+
+typedef void (*glMemoryBarrierPROC)(GLenum e);
+glMemoryBarrierPROC glMemoryBarrierSRC = NULL;
+
+typedef void (*glBindImageTexturePROC)(GLuint unit, GLuint texture, GLint level, GLboolean layered, GLint layer, GLenum access, GLenum format);
+glBindImageTexturePROC glBindImageTextureSRC = NULL;
+
+#endif
+
 #if defined(RSGL_OPENGL_ES2) && !defined(RSGL_OPENGL_ES3)
 typedef void (* PFNGLGENVERTEXARRAYSOESPROC) (GLsizei n, GLuint *arrays);
 typedef void (* PFNGLBINDVERTEXARRAYOESPROC) (GLuint array);
@@ -207,6 +226,12 @@ glDeleteVertexArraysPROC glDeleteVertexArraysSRC = NULL;
 #define glGetUniformLocation glGetUniformLocationSRC
 #define glUniformMatrix4fv glUniformMatrix4fvSRC
 
+#ifdef RSGL_USE_COMPUTE
+#define glMemoryBarrier glMemoryBarrierSRC
+#define glDispatchCompute glDispatchComputeSRC
+#define glBindImageTexture glBindImageTextureSRC
+#endif
+
 extern int RSGL_loadGLModern(RSGLloadfunc proc);
 #endif
 
@@ -239,6 +264,12 @@ RSGL_renderer RSGL_GL_renderer() {
     renderer.createAtlas = RFont_GL_create_atlas;
     renderer.resizeAtlas = RFont_GL_resize_atlas;
     renderer.bitmapToAtlas = RFont_GL_bitmap_to_atlas;
+
+#ifdef RSGL_USE_COMPUTE
+	renderer.createComputeProgram = RSGL_GL_createComputeProgram;
+	renderer.dispatchComputeProgram = RSGL_GL_dispatchComputeProgram;
+	renderer.bindComputeTexture = RSGL_GL_bindComputeTexture;
+#endif
     return renderer;
 }
 
@@ -254,7 +285,7 @@ void RSGL_GL_init(void* proc, RSGL_RENDER_INFO* info) {
     RSGL_UNUSED(info);
 
     #ifdef RSGL_MODERN_OPENGL
-    #ifndef __EMSCRIPTEN__
+    #if !defined(__EMSCRIPTEN__) && !defined(RSGL_NO_GL_LOADER)
     if (RSGL_loadGLModern((RSGLloadfunc)proc)) {
         RSGL_GL_legacy = 2;
         #ifdef RSGL_DEBUG
@@ -527,7 +558,7 @@ void RSGL_GL_batch(RSGL_RENDER_INFO* info) {
                 info->batches[i].tex = RSGL_gl.defaultTex;
             
             glBindTexture(GL_TEXTURE_2D, info->batches[i].tex);
-            glLineWidth(info->batches[i].lineWidth);
+            glLineWidth(info->batches[i].lineWidth > 0 ? info->batches[i].lineWidth : 0.1f);
             
             if (RSGL_args.program)
                 glUseProgram(RSGL_args.program);
@@ -563,7 +594,7 @@ void RSGL_GL_batch(RSGL_RENDER_INFO* info) {
         for (i = 0; i < info->len; i++) {
             glEnable(GL_TEXTURE_2D);
             glBindTexture(GL_TEXTURE_2D, info->batches[i].tex);
-            glLineWidth(info->batches[i].lineWidth);
+            glLineWidth(info->batches[i].lineWidth > 0 ? info->batches[i].lineWidth : 0.1f);
 
             u32 mode = info->batches[i].type;
             glEnable(GL_BLEND);
@@ -713,16 +744,13 @@ void RSGL_debug_shader(u32 src, const char *shader, const char *action) {
 	else {
 		printf("%s Shader failed to %s.\n", shader, action);
 
+		GLchar infoLog[512];
 		if (action[0] == 'c') {
-			GLint infoLogLength;
-			glGetShaderiv(src, GL_INFO_LOG_LENGTH, &infoLogLength);
-
-			if (infoLogLength > 0) {
-				GLchar *infoLog = (GLchar *)RSGL_MALLOC(infoLogLength);
-				glGetShaderInfoLog(src, infoLogLength, NULL, infoLog);
-				printf("%s Shader info log:\n%s\n", shader, infoLog);
-				free(infoLog);
-			}
+			glGetShaderInfoLog(src, 512, NULL, infoLog);
+			printf("%s Shader info log:\n%s\n", shader, infoLog);
+		} else {
+			glGetProgramInfoLog(src, 512, NULL, infoLog);
+			printf("%s info log:\n%s\n", shader, infoLog); 
 		}
 
 		RSGL_opengl_getError();
@@ -758,10 +786,12 @@ RSGL_programInfo RSGL_GL_createProgram(const char* VShaderCode, const char* FSha
 	glBindAttribLocation(program.program, 2, colorName);
 
 	glLinkProgram(program.program);
+	RSGL_debug_shader(program.program, "Program", "link");
 
 	glDeleteShader(vShader);
 	glDeleteShader(fShader);
 	
+	program.type = RSGL_shaderTypeStandard;
 	return program;
 }
 
@@ -920,6 +950,45 @@ void RFont_GL_bitmap_to_atlas(RFont_texture atlas, u8* bitmap, float x, float y,
    glBindTexture(GL_TEXTURE_2D, 0);
 }
 
+#ifdef RSGL_USE_COMPUTE
+RSGL_programInfo RSGL_GL_createComputeProgram(const char* CShaderCode) {
+	RSGL_programInfo program;
+	program.type = RSGL_shaderTypeCompute;
+
+	u32 compute = glCreateShader(GL_COMPUTE_SHADER);
+	glShaderSource(compute, 1, &CShaderCode, NULL);
+	glCompileShader(compute);
+	RSGL_debug_shader(compute, "Compute", "compile");
+
+	program.program = glCreateProgram();
+	glAttachShader(program.program, compute);
+	glLinkProgram(program.program);
+	RSGL_debug_shader(program.program, "Program", "link");
+
+	glDeleteShader(compute);
+
+	return program;
+}
+
+void RSGL_GL_dispatchComputeProgram(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z) {
+	glUseProgram(program.program);
+	glDispatchCompute(groups_x, groups_y, groups_z);
+	glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+}
+
+void RSGL_GL_bindComputeTexture(u32 texture, u8 format) {
+	u16 c = 0;
+   switch (format) {
+       case 2: c = GL_RG8; break;
+       case 3: c = GL_RGB8; break;
+       case 4: c = GL_RGBA8; break;
+       default: break;
+   }
+	glBindImageTexture(0, texture, 0, GL_FALSE, 0, GL_READ_WRITE, c);
+}
+
+#endif
+
 #ifdef RSGL_MODERN_OPENGL
 
 #ifndef RSGL_NO_GL_LOADER
@@ -959,7 +1028,11 @@ int RSGL_loadGLModern(RSGLloadfunc proc) {
     RSGL_PROC_DEF(proc, glUniform2f);
     RSGL_PROC_DEF(proc, glUniform3f);
     RSGL_PROC_DEF(proc, glUniform4f);
-
+    #ifdef RSGL_USE_COMPUTE
+    RSGL_PROC_DEF(proc, glDispatchCompute);
+	 RSGL_PROC_DEF(proc, glMemoryBarrier);
+	 RSGL_PROC_DEF(proc, glBindImageTexture);
+    #endif
     #if defined(RSGL_OPENGL_ES2) && !defined(RSGL_OPENGL_ES3)
         glGenVertexArraysSRC = (PFNGLGENVERTEXARRAYSOESPROC)((RSGLloadfunc)loader)("glGenVertexArraysOES");
         glBindVertexArraySRC = (PFNGLBINDVERTEXARRAYOESPROC)((RSGLloadfunc)loader)("glBindVertexArrayOES");

--- a/RSGL_gl.h
+++ b/RSGL_gl.h
@@ -1,4 +1,3 @@
-#include <GL/glext.h>
 #ifndef RSGL_H
 #include "RSGL.h"
 #endif

--- a/RSGL_gl.h
+++ b/RSGL_gl.h
@@ -705,6 +705,7 @@ void RSGL_GL_updateTexture(RSGL_texture texture, u8* bitmap, RSGL_area memsize, 
 #define GL_INFO_LOG_LENGTH                0x8B84 
 #endif
 
+#ifdef RSGL_DEBUG
 void RSGL_opengl_getError(void) {
 	GLenum err;
 	while ((err = glGetError()) != GL_NO_ERROR) {
@@ -731,6 +732,7 @@ void RSGL_opengl_getError(void) {
 	}
 }
 
+
 void RSGL_debug_shader(u32 src, const char *shader, const char *action) {
     GLint status;
 	if (action[0] == 'l')
@@ -755,6 +757,7 @@ void RSGL_debug_shader(u32 src, const char *shader, const char *action) {
 		RSGL_opengl_getError();
 	}
 }
+#endif
 
 RSGL_programInfo RSGL_GL_createProgram(const char* VShaderCode, const char* FShaderCode, const char* posName, const char* texName, const char* colorName) {
 	RSGL_programInfo program;
@@ -765,14 +768,18 @@ RSGL_programInfo RSGL_GL_createProgram(const char* VShaderCode, const char* FSha
 	glShaderSource(vShader, 1, &VShaderCode, NULL);
 	glCompileShader(vShader);
 
+#ifdef RSGL_DEBUG
 	RSGL_debug_shader(vShader, "Vertex", "compile");
+#endif
 
 	/* compile fragment shader */
 	fShader = glCreateShader(GL_FRAGMENT_SHADER);
 	glShaderSource(fShader, 1, &FShaderCode, NULL);
 	glCompileShader(fShader);
 
+#ifdef RSGL_DEBUG
 	RSGL_debug_shader(fShader, "Fragment", "compile");
+#endif
 
 	/* create program and link vertex and fragment shaders */
 	program.program = glCreateProgram();
@@ -785,7 +792,10 @@ RSGL_programInfo RSGL_GL_createProgram(const char* VShaderCode, const char* FSha
 	glBindAttribLocation(program.program, 2, colorName);
 
 	glLinkProgram(program.program);
+
+#ifdef RSGL_DEBUG
 	RSGL_debug_shader(program.program, "Program", "link");
+#endif
 
 	glDeleteShader(vShader);
 	glDeleteShader(fShader);
@@ -974,12 +984,17 @@ RSGL_programInfo RSGL_GL_createComputeProgram(const char* CShaderCode) {
 	u32 compute = glCreateShader(GL_COMPUTE_SHADER);
 	glShaderSource(compute, 1, &CShaderCode, NULL);
 	glCompileShader(compute);
+
+#ifdef RSGL_DEBUG
 	RSGL_debug_shader(compute, "Compute", "compile");
+#endif
 
 	program.program = glCreateProgram();
 	glAttachShader(program.program, compute);
 	glLinkProgram(program.program);
+#ifdef RSGL_DEBUG
 	RSGL_debug_shader(program.program, "Program", "link");
+#endif
 
 	glDeleteShader(compute);
 

--- a/RSGL_gl.h
+++ b/RSGL_gl.h
@@ -950,6 +950,23 @@ void RFont_GL_bitmap_to_atlas(RFont_texture atlas, u8* bitmap, float x, float y,
 }
 
 #ifdef RSGL_USE_COMPUTE
+
+#ifndef GL_RG8
+#define GL_RG8 0x822B
+#endif
+
+#ifndef GL_READ_WRITE
+#define GL_READ_WRITE 0x88BA
+#endif
+
+#ifndef GL_COMPUTE_SHADER
+#define GL_COMPUTE_SHADER 0x91B9
+#endif
+
+#ifndef GL_SHADER_IMAGE_ACCESS_BARRIER_BIT
+#define GL_SHADER_IMAGE_ACCESS_BARRIER_BIT 0x00000020
+#endif
+
 RSGL_programInfo RSGL_GL_createComputeProgram(const char* CShaderCode) {
 	RSGL_programInfo program;
 	program.type = RSGL_shaderTypeCompute;
@@ -975,21 +992,6 @@ void RSGL_GL_dispatchComputeProgram(RSGL_programInfo program, u32 groups_x, u32 
 	glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
 }
 
-#ifndef GL_RG8
-#define GL_RG8 0x822B
-#endif
-
-#ifndef GL_READ_WRITE
-#define GL_READ_WRITE 0x88BA
-#endif
-
-#ifndef GL_COMPUTE_SHADER
-#define GL_COMPUTE_SHADER 0x91B9
-#endif
-
-#ifndef GL_SHADER_IMAGE_ACCESS_BARRIER_BIT
-#define GL_SHADER_IMAGE_ACCESS_BARRIER_BIT 0x00000020
-#endif
 
 void RSGL_GL_bindComputeTexture(u32 texture, u8 format) {
 	u16 c = 0;

--- a/RSGL_gl.h
+++ b/RSGL_gl.h
@@ -975,6 +975,22 @@ void RSGL_GL_dispatchComputeProgram(RSGL_programInfo program, u32 groups_x, u32 
 	glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
 }
 
+#ifndef GL_RG8
+#define GL_RG8 0x822B
+#endif
+
+#ifndef GL_READ_WRITE
+#define GL_READ_WRITE 0x88BA
+#endif
+
+#ifndef GL_COMPUTE_SHADER
+#define GL_COMPUTE_SHADER 0x91B9
+#endif
+
+#ifndef GL_SHADER_IMAGE_ACCESS_BARRIER_BIT
+#define GL_SHADER_IMAGE_ACCESS_BARRIER_BIT 0x00000020
+#endif
+
 void RSGL_GL_bindComputeTexture(u32 texture, u8 format) {
 	u16 c = 0;
    switch (format) {

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,3 +1,4 @@
 -D RSGL_IMPLEMENTATION
+-D RSGL_USE_COMPUTE
 -I./
 -I./examples/deps

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -72,7 +72,8 @@ EXAMPLE_OUTPUTS = \
 	basics/textures  \
 	advanced/shader \
 	basics/shapes  \
-	basics/camera
+	basics/camera	\
+	advanced/compute
 
 all: xdg-shell.c $(EXAMPLE_OUTPUTS) advanced/rsoft 
 

--- a/examples/advanced/compute.c
+++ b/examples/advanced/compute.c
@@ -1,0 +1,69 @@
+#define RGFW_IMPLEMENTATION
+#include "RGFW.h"
+
+#define RSGL_IMPLEMENTATION
+#define RSGL_USE_COMPUTE
+#include "RSGL.h"
+#include "RSGL_gl.h"
+
+/*
+ 	Example showing off basic compute shader use
+
+	Written by TKPMonke
+*/
+
+const static char* ComputeShader = RSGL_MULTILINE_STR(
+	\x23version 430 core		\n
+	layout (local_size_x = 10, local_size_y = 10, local_size_z = 1) in;		\n
+	layout (rgba8, binding = 0) uniform image2D output_img;		\n
+	layout (location = 0) uniform float u_time; 					\n
+	layout (location = 1) uniform vec2 u_screen_size;			\n
+	
+	const float c_speed = 100;
+	void main() {
+		vec4 value = vec4(0, 0, 0, 1);
+		ivec2 texelCoord = ivec2(gl_GlobalInvocationID.xy);
+
+		value.x = mod(float(texelCoord.x)+u_time * 100, u_screen_size.x)/gl_NumWorkGroups.x; 
+		value.y = mod(float(texelCoord.y)+u_time * 100, u_screen_size.y)/gl_NumWorkGroups.y; 
+
+		imageStore(output_img, texelCoord, value);
+	}
+);
+
+int main(void) {
+	RGFW_window* window = RGFW_createWindow("RSGL Shader example", RGFW_RECT(0, 0, 750, 500), RGFW_windowCenter);
+	
+	RSGL_init(RSGL_AREA(window->r.w, window->r.h), RGFW_getProcAddress, RSGL_GL_renderer());
+
+	RSGL_programInfo program = RSGL_renderCreateComputeProgram(ComputeShader);
+	u32 texture = RSGL_renderCreateTexture(NULL, RSGL_AREA(200, 200), 4);
+
+	RGFW_window_showMouse(window, 0);
+
+	while (RGFW_window_shouldClose(window) == false) {
+		while (RGFW_window_checkEvent(window)) {
+			if (window->event.type == RGFW_quit) break;
+		}
+
+		RSGL_setProgram(program.program);
+		RSGL_GL_bindComputeTexture(texture, 4);
+		RSGL_renderSetShaderValue(program.program, "u_time", (float[1]){RGFW_getTime()}, 1);
+		RSGL_renderSetShaderValue(program.program, "u_screen_size", (float[2]){20, 20}, 2);
+		RSGL_renderDispatchComputeProgram(program, 20, 20, 1);
+
+		RSGL_clear(RSGL_RGB(20, 20, 20));
+		RSGL_setProgram(0);
+		RSGL_setTexture(texture);
+		RSGL_drawRect(RSGL_RECT(100, 200, 200, 200), RSGL_RGB(255, 255, 255));
+
+
+		RSGL_draw();
+		RGFW_window_swapBuffers(window);
+	}
+
+	RSGL_renderDeleteProgram(program);
+	RSGL_renderDeleteTexture(texture);
+	RSGL_free();
+	RGFW_window_close(window);
+}

--- a/examples/advanced/compute.c
+++ b/examples/advanced/compute.c
@@ -12,6 +12,8 @@
 	Written by TKPMonke
 */
 
+#ifndef __EMSCRIPTEN__
+
 const static char* ComputeShader = RSGL_MULTILINE_STR(
 	\x23version 430 core		\n
 	layout (local_size_x = 10, local_size_y = 10, local_size_z = 1) in;		\n
@@ -67,3 +69,5 @@ int main(void) {
 	RSGL_free();
 	RGFW_window_close(window);
 }
+
+#endif // __EMSCRIPTEN__

--- a/examples/advanced/compute.c
+++ b/examples/advanced/compute.c
@@ -70,4 +70,11 @@ int main(void) {
 	RGFW_window_close(window);
 }
 
+#else
+
+int main(void) {
+	printf("This example does not support emscripten\n");
+	return 1;
+}
+
 #endif // __EMSCRIPTEN__

--- a/examples/advanced/compute.c
+++ b/examples/advanced/compute.c
@@ -47,7 +47,7 @@ int main(void) {
 		}
 
 		RSGL_setProgram(program.program);
-		RSGL_GL_bindComputeTexture(texture, 4);
+		RSGL_renderBindComputeTexture(texture, 4);
 		RSGL_renderSetShaderValue(program.program, "u_time", (float[1]){RGFW_getTime()}, 1);
 		RSGL_renderSetShaderValue(program.program, "u_screen_size", (float[2]){20, 20}, 2);
 		RSGL_renderDispatchComputeProgram(program, 20, 20, 1);


### PR DESCRIPTION
Adds support for compute shaders along with an example using a quad that has a moving uv texture.

Also fixed a few issues i found

- glLineWidth being set to 0 (not allowed)
- fixed RSGL_NO_GL_LOADER not working
- RSGL_debug_shader wasn't being called to link shaders
- RSGL_debug_shader no longer needs dynamic allocation