### PR TITLE
Added explicit casts to remove warnings

### DIFF
--- a/RFont.h
+++ b/RFont.h
@@ -91,31 +91,31 @@ int main () {
 #include <string.h>
 
 #if !defined(u8)
-   #if defined(_MSC_VER) || defined(__SYMBIAN32__)
-      typedef unsigned char   u8;
-      typedef signed char     i8;
-      typedef unsigned short  u16;
-      typedef signed short    i16;
-      typedef unsigned int    u32;
-      typedef signed int      i32;
-      typedef unsigned long   u64;
-      typedef signed long     i64;
-   #else
-      #include <stdint.h>
+	#if defined(_MSC_VER) || defined(__SYMBIAN32__)
+		typedef unsigned char 	u8;
+		typedef signed char		i8;
+		typedef unsigned short  u16;
+		typedef signed short 	i16;
+		typedef unsigned int 	u32;
+		typedef signed int		i32;
+		typedef unsigned long	u64;
+		typedef signed long		i64;
+	#else
+		#include <stdint.h>
 
-      typedef uint8_t     u8;
-      typedef int8_t      i8;
-      typedef uint16_t   u16;
-      typedef int16_t    i16;
-      typedef uint32_t   u32;
-      typedef int32_t    i32;
-      typedef uint64_t   u64;
-      typedef int64_t    i64;
-   #endif
+		typedef uint8_t     u8;
+		typedef int8_t      i8;
+		typedef uint16_t   u16;
+		typedef int16_t    i16;
+		typedef uint32_t   u32;
+		typedef int32_t    i32;
+		typedef uint64_t   u64;
+		typedef int64_t    i64;
+	#endif
 #endif
 
 #if !defined(b8)
-   typedef u8 b8;
+	typedef u8 b8;
 #endif
 
 /* 
@@ -683,7 +683,7 @@ RFont_glyph RFont_font_add_codepoint(RFont_font* font, u32 codepoint, size_t siz
 }
 
 RFont_glyph RFont_font_add_codepointPro(RFont_font* font, u32 codepoint, size_t size, b8 fallback) {
-   u32 i;
+	u32 i;
    for (i = 0; i < font->glyph_len; i++)
       if (font->glyphs[i].codepoint == codepoint && font->glyphs[i].size == size)
          return font->glyphs[i];
@@ -949,7 +949,7 @@ RFont_area RFont_draw_text_len(RFont_font* font, const char* text, size_t len, f
 #endif
 
 #ifndef GL_PERSPECTIVE_CORRECTION_HINT
-#define GL_PERSPECTIVE_CORRECTION_HINT    0x0C50
+#define GL_PERSPECTIVE_CORRECTION_HINT		0x0C50
 #endif
 
 #ifndef GL_TEXTURE_SWIZZLE_RGBA
@@ -957,11 +957,11 @@ RFont_area RFont_draw_text_len(RFont_font* font, const char* text, size_t len, f
 #endif
 
 #ifndef GL_TEXTURE0
-#define GL_TEXTURE0           0x84C0
+#define GL_TEXTURE0				0x84C0
 #endif
 
 #ifndef GL_CLAMP_TO_EDGE
-#define GL_CLAMP_TO_EDGE         0x812F
+#define GL_CLAMP_TO_EDGE			0x812F
 #endif
 
 #ifdef RFONT_DEBUG
@@ -1002,7 +1002,7 @@ void RFont_opengl_getError(void) {
                   break;
             case GL_STACK_UNDERFLOW:
                   printf("OpenGL error: GL_STACK_UNDERFLOW\n");
-                  break;   
+                  break;	
             default:
                   printf("OpenGL error: Unknown error code 0x%x\n", err);
                   break;
@@ -1039,8 +1039,8 @@ RFont_texture RFont_create_atlas(u32 atlasWidth, u32 atlasHeight) {
    RFONT_FREE(data);
 
    glBindTexture(GL_TEXTURE_2D, id);
-   static GLint swizzleRgbaParams[4] = {GL_ONE, GL_ONE, GL_ONE, GL_RED};
-   glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleRgbaParams);
+	static GLint swizzleRgbaParams[4] = {GL_ONE, GL_ONE, GL_ONE, GL_RED};
+	glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleRgbaParams);
 
    glBindTexture(GL_TEXTURE_2D, 0);
    return id;
@@ -1068,8 +1068,8 @@ b8 RFont_resize_atlas(RFont_texture* atlas, u32 newWidth, u32 newHeight) {
    
    /* swizzle new atlas */
    glBindTexture(GL_TEXTURE_2D, newAtlas);
-   static GLint swizzleRgbaParams[4] = {GL_ONE, GL_ONE, GL_ONE, GL_RED};
-   glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleRgbaParams);
+	static GLint swizzleRgbaParams[4] = {GL_ONE, GL_ONE, GL_ONE, GL_RED};
+	glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleRgbaParams);
 
    glBindTexture(GL_TEXTURE_2D, 0);
 
@@ -1085,32 +1085,32 @@ b8 RFont_resize_atlas(RFont_texture* atlas, u32 newWidth, u32 newHeight) {
 
 void RFont_push_pixel_values(GLint alignment, GLint rowLength, GLint skipPixels, GLint skipRows);
 void RFont_push_pixel_values(GLint alignment, GLint rowLength, GLint skipPixels, GLint skipRows) {
-   glPixelStorei(GL_UNPACK_ALIGNMENT, alignment);
-   glPixelStorei(GL_UNPACK_ROW_LENGTH, rowLength);
-   glPixelStorei(GL_UNPACK_SKIP_PIXELS, skipPixels);
-   glPixelStorei(GL_UNPACK_SKIP_ROWS, skipRows);
+	glPixelStorei(GL_UNPACK_ALIGNMENT, alignment);
+	glPixelStorei(GL_UNPACK_ROW_LENGTH, rowLength);
+	glPixelStorei(GL_UNPACK_SKIP_PIXELS, skipPixels);
+	glPixelStorei(GL_UNPACK_SKIP_ROWS, skipRows);
 }
 
 void RFont_bitmap_to_atlas(RFont_texture atlas, u8* bitmap, float x, float y, float w, float h) {
    glEnable(GL_TEXTURE_2D);
    
-   GLint alignment, rowLength, skipPixels, skipRows;
+	GLint alignment, rowLength, skipPixels, skipRows;
    glGetIntegerv(GL_UNPACK_ALIGNMENT, &alignment);
-   glGetIntegerv(GL_UNPACK_ROW_LENGTH, &rowLength);
-   glGetIntegerv(GL_UNPACK_SKIP_PIXELS, &skipPixels);
-   glGetIntegerv(GL_UNPACK_SKIP_ROWS, &skipRows);
+	glGetIntegerv(GL_UNPACK_ROW_LENGTH, &rowLength);
+	glGetIntegerv(GL_UNPACK_SKIP_PIXELS, &skipPixels);
+	glGetIntegerv(GL_UNPACK_SKIP_ROWS, &skipRows);
    
    #if !defined(RFONT_RENDER_LEGACY)
    glActiveTexture(GL_TEXTURE0 + atlas - 1);
    #endif
 
-   glBindTexture(GL_TEXTURE_2D, atlas);
+	glBindTexture(GL_TEXTURE_2D, atlas);
 
-   RFont_push_pixel_values(1, w, 0, 0);
+	RFont_push_pixel_values(1, w, 0, 0);
 
-   glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, GL_RED, GL_UNSIGNED_BYTE, bitmap);
+	glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, GL_RED, GL_UNSIGNED_BYTE, bitmap);
 
-   RFont_push_pixel_values(alignment, rowLength, skipPixels, skipRows);
+	RFont_push_pixel_values(alignment, rowLength, skipPixels, skipRows);
 
    glBindTexture(GL_TEXTURE_2D, 0);
 }
@@ -1128,7 +1128,7 @@ void RFont_render_text(RFont_texture atlas, float* verts, float* tcoords, size_t
 
    rglMatrixMode(RGL_MODELVIEW);
    rglLoadIdentity();
-   rglPushMatrix();
+	rglPushMatrix();
 
    glDisable(GL_DEPTH_TEST);
    glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
@@ -1141,19 +1141,19 @@ void RFont_render_text(RFont_texture atlas, float* verts, float* tcoords, size_t
 
    rglSetTexture(atlas);
    
-   rglBegin(RGL_TRIANGLES_2D);
+	rglBegin(RGL_TRIANGLES_2D);
 
-   size_t i;
+	size_t i;
    size_t tIndex = 0;
 
-   for (i = 0; i < (nverts * 3); i += 3) {
-      rglTexCoord2f(tcoords[tIndex], tcoords[tIndex + 1]);
+	for (i = 0; i < (nverts * 3); i += 3) {
+		rglTexCoord2f(tcoords[tIndex], tcoords[tIndex + 1]);
       tIndex += 2;
-      
+		
       rglVertex2f(verts[i], verts[i + 1]);
-   }
-   rglEnd();
-   rglPopMatrix();
+	}
+	rglEnd();
+	rglPopMatrix();
    
    rglSetTexture(0);
    glBindTexture(GL_TEXTURE_2D, 0);
@@ -1190,21 +1190,21 @@ void RFont_render_text(RFont_texture atlas, float* verts, float* tcoords, size_t
 
    glBindTexture(GL_TEXTURE_2D, atlas);
 
-   glPushMatrix();
+	glPushMatrix();
 
-   glBegin(GL_TRIANGLES);
+	glBegin(GL_TRIANGLES);
 
-   size_t i;
+	size_t i;
    size_t tIndex = 0;
 
-   for (i = 0; i < (nverts * 3); i += 3) {
-      glTexCoord2f(tcoords[tIndex], tcoords[tIndex + 1]);
-      tIndex += 2;
+	for (i = 0; i < (nverts * 3); i += 3) {
+		glTexCoord2f(tcoords[tIndex], tcoords[tIndex + 1]);
+		tIndex += 2;
 
       glVertex2f(verts[i], verts[i + 1]);
-   }
-   glEnd();
-   glPopMatrix();
+	}
+	glEnd();
+	glPopMatrix();
 
    glBindTexture(GL_TEXTURE_2D, 0);
    glEnable(GL_DEPTH_TEST);
@@ -1452,7 +1452,7 @@ void RFont_render_text(RFont_texture atlas, float* verts, float* tcoords, size_t
    }
 
    glBindTexture(GL_TEXTURE_2D, 0);
-   glDisable(GL_TEXTURE_2D);
+	glDisable(GL_TEXTURE_2D);
    glEnable(GL_DEPTH_TEST);
 }
 

--- a/RFont.h
+++ b/RFont.h
@@ -91,31 +91,31 @@ int main () {
 #include <string.h>
 
 #if !defined(u8)
-	#if defined(_MSC_VER) || defined(__SYMBIAN32__)
-		typedef unsigned char 	u8;
-		typedef signed char		i8;
-		typedef unsigned short  u16;
-		typedef signed short 	i16;
-		typedef unsigned int 	u32;
-		typedef signed int		i32;
-		typedef unsigned long	u64;
-		typedef signed long		i64;
-	#else
-		#include <stdint.h>
+   #if defined(_MSC_VER) || defined(__SYMBIAN32__)
+      typedef unsigned char   u8;
+      typedef signed char     i8;
+      typedef unsigned short  u16;
+      typedef signed short    i16;
+      typedef unsigned int    u32;
+      typedef signed int      i32;
+      typedef unsigned long   u64;
+      typedef signed long     i64;
+   #else
+      #include <stdint.h>
 
-		typedef uint8_t     u8;
-		typedef int8_t      i8;
-		typedef uint16_t   u16;
-		typedef int16_t    i16;
-		typedef uint32_t   u32;
-		typedef int32_t    i32;
-		typedef uint64_t   u64;
-		typedef int64_t    i64;
-	#endif
+      typedef uint8_t     u8;
+      typedef int8_t      i8;
+      typedef uint16_t   u16;
+      typedef int16_t    i16;
+      typedef uint32_t   u32;
+      typedef int32_t    i32;
+      typedef uint64_t   u64;
+      typedef int64_t    i64;
+   #endif
 #endif
 
 #if !defined(b8)
-	typedef u8 b8;
+   typedef u8 b8;
 #endif
 
 /* 
@@ -683,7 +683,7 @@ RFont_glyph RFont_font_add_codepoint(RFont_font* font, u32 codepoint, size_t siz
 }
 
 RFont_glyph RFont_font_add_codepointPro(RFont_font* font, u32 codepoint, size_t size, b8 fallback) {
-	u32 i;
+   u32 i;
    for (i = 0; i < font->glyph_len; i++)
       if (font->glyphs[i].codepoint == codepoint && font->glyphs[i].size == size)
          return font->glyphs[i];
@@ -789,7 +789,7 @@ RFont_area RFont_text_area_len(RFont_font* font, const char* text, size_t len, u
       x += (float)glyph.advance + spacing;
    }
 
-   return (RFont_area){(u32)x, y * size};
+   return (RFont_area){(u32)x, (u32)(y * size)};
 }
 
 RFont_area RFont_draw_text(RFont_font* font, const char* text, float x, float y, u32 size) {
@@ -933,7 +933,7 @@ RFont_area RFont_draw_text_len(RFont_font* font, const char* text, size_t len, f
       RFont_render_text(font->atlas, verts, tcoords, i / 3);
    #endif
    
-   return (RFont_area){(u32)(x - startX), (u32)(y - startY) + (-font->descent * scale)};
+   return (RFont_area){(u32)(x - startX), (u32)(y - startY) + (u32)(-font->descent * scale)};
 }
 
 #if !defined(RFONT_NO_OPENGL) && !defined(RFONT_NO_GRAPHICS)
@@ -949,7 +949,7 @@ RFont_area RFont_draw_text_len(RFont_font* font, const char* text, size_t len, f
 #endif
 
 #ifndef GL_PERSPECTIVE_CORRECTION_HINT
-#define GL_PERSPECTIVE_CORRECTION_HINT		0x0C50
+#define GL_PERSPECTIVE_CORRECTION_HINT    0x0C50
 #endif
 
 #ifndef GL_TEXTURE_SWIZZLE_RGBA
@@ -957,11 +957,11 @@ RFont_area RFont_draw_text_len(RFont_font* font, const char* text, size_t len, f
 #endif
 
 #ifndef GL_TEXTURE0
-#define GL_TEXTURE0				0x84C0
+#define GL_TEXTURE0           0x84C0
 #endif
 
 #ifndef GL_CLAMP_TO_EDGE
-#define GL_CLAMP_TO_EDGE			0x812F
+#define GL_CLAMP_TO_EDGE         0x812F
 #endif
 
 #ifdef RFONT_DEBUG
@@ -1002,7 +1002,7 @@ void RFont_opengl_getError(void) {
                   break;
             case GL_STACK_UNDERFLOW:
                   printf("OpenGL error: GL_STACK_UNDERFLOW\n");
-                  break;	
+                  break;   
             default:
                   printf("OpenGL error: Unknown error code 0x%x\n", err);
                   break;
@@ -1039,8 +1039,8 @@ RFont_texture RFont_create_atlas(u32 atlasWidth, u32 atlasHeight) {
    RFONT_FREE(data);
 
    glBindTexture(GL_TEXTURE_2D, id);
-	static GLint swizzleRgbaParams[4] = {GL_ONE, GL_ONE, GL_ONE, GL_RED};
-	glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleRgbaParams);
+   static GLint swizzleRgbaParams[4] = {GL_ONE, GL_ONE, GL_ONE, GL_RED};
+   glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleRgbaParams);
 
    glBindTexture(GL_TEXTURE_2D, 0);
    return id;
@@ -1068,8 +1068,8 @@ b8 RFont_resize_atlas(RFont_texture* atlas, u32 newWidth, u32 newHeight) {
    
    /* swizzle new atlas */
    glBindTexture(GL_TEXTURE_2D, newAtlas);
-	static GLint swizzleRgbaParams[4] = {GL_ONE, GL_ONE, GL_ONE, GL_RED};
-	glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleRgbaParams);
+   static GLint swizzleRgbaParams[4] = {GL_ONE, GL_ONE, GL_ONE, GL_RED};
+   glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleRgbaParams);
 
    glBindTexture(GL_TEXTURE_2D, 0);
 
@@ -1085,32 +1085,32 @@ b8 RFont_resize_atlas(RFont_texture* atlas, u32 newWidth, u32 newHeight) {
 
 void RFont_push_pixel_values(GLint alignment, GLint rowLength, GLint skipPixels, GLint skipRows);
 void RFont_push_pixel_values(GLint alignment, GLint rowLength, GLint skipPixels, GLint skipRows) {
-	glPixelStorei(GL_UNPACK_ALIGNMENT, alignment);
-	glPixelStorei(GL_UNPACK_ROW_LENGTH, rowLength);
-	glPixelStorei(GL_UNPACK_SKIP_PIXELS, skipPixels);
-	glPixelStorei(GL_UNPACK_SKIP_ROWS, skipRows);
+   glPixelStorei(GL_UNPACK_ALIGNMENT, alignment);
+   glPixelStorei(GL_UNPACK_ROW_LENGTH, rowLength);
+   glPixelStorei(GL_UNPACK_SKIP_PIXELS, skipPixels);
+   glPixelStorei(GL_UNPACK_SKIP_ROWS, skipRows);
 }
 
 void RFont_bitmap_to_atlas(RFont_texture atlas, u8* bitmap, float x, float y, float w, float h) {
    glEnable(GL_TEXTURE_2D);
    
-	GLint alignment, rowLength, skipPixels, skipRows;
+   GLint alignment, rowLength, skipPixels, skipRows;
    glGetIntegerv(GL_UNPACK_ALIGNMENT, &alignment);
-	glGetIntegerv(GL_UNPACK_ROW_LENGTH, &rowLength);
-	glGetIntegerv(GL_UNPACK_SKIP_PIXELS, &skipPixels);
-	glGetIntegerv(GL_UNPACK_SKIP_ROWS, &skipRows);
+   glGetIntegerv(GL_UNPACK_ROW_LENGTH, &rowLength);
+   glGetIntegerv(GL_UNPACK_SKIP_PIXELS, &skipPixels);
+   glGetIntegerv(GL_UNPACK_SKIP_ROWS, &skipRows);
    
    #if !defined(RFONT_RENDER_LEGACY)
    glActiveTexture(GL_TEXTURE0 + atlas - 1);
    #endif
 
-	glBindTexture(GL_TEXTURE_2D, atlas);
+   glBindTexture(GL_TEXTURE_2D, atlas);
 
-	RFont_push_pixel_values(1, w, 0, 0);
+   RFont_push_pixel_values(1, w, 0, 0);
 
-	glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, GL_RED, GL_UNSIGNED_BYTE, bitmap);
+   glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, GL_RED, GL_UNSIGNED_BYTE, bitmap);
 
-	RFont_push_pixel_values(alignment, rowLength, skipPixels, skipRows);
+   RFont_push_pixel_values(alignment, rowLength, skipPixels, skipRows);
 
    glBindTexture(GL_TEXTURE_2D, 0);
 }
@@ -1128,7 +1128,7 @@ void RFont_render_text(RFont_texture atlas, float* verts, float* tcoords, size_t
 
    rglMatrixMode(RGL_MODELVIEW);
    rglLoadIdentity();
-	rglPushMatrix();
+   rglPushMatrix();
 
    glDisable(GL_DEPTH_TEST);
    glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
@@ -1141,19 +1141,19 @@ void RFont_render_text(RFont_texture atlas, float* verts, float* tcoords, size_t
 
    rglSetTexture(atlas);
    
-	rglBegin(RGL_TRIANGLES_2D);
+   rglBegin(RGL_TRIANGLES_2D);
 
-	size_t i;
+   size_t i;
    size_t tIndex = 0;
 
-	for (i = 0; i < (nverts * 3); i += 3) {
-		rglTexCoord2f(tcoords[tIndex], tcoords[tIndex + 1]);
+   for (i = 0; i < (nverts * 3); i += 3) {
+      rglTexCoord2f(tcoords[tIndex], tcoords[tIndex + 1]);
       tIndex += 2;
-		
+      
       rglVertex2f(verts[i], verts[i + 1]);
-	}
-	rglEnd();
-	rglPopMatrix();
+   }
+   rglEnd();
+   rglPopMatrix();
    
    rglSetTexture(0);
    glBindTexture(GL_TEXTURE_2D, 0);
@@ -1190,21 +1190,21 @@ void RFont_render_text(RFont_texture atlas, float* verts, float* tcoords, size_t
 
    glBindTexture(GL_TEXTURE_2D, atlas);
 
-	glPushMatrix();
+   glPushMatrix();
 
-	glBegin(GL_TRIANGLES);
+   glBegin(GL_TRIANGLES);
 
-	size_t i;
+   size_t i;
    size_t tIndex = 0;
 
-	for (i = 0; i < (nverts * 3); i += 3) {
-		glTexCoord2f(tcoords[tIndex], tcoords[tIndex + 1]);
-		tIndex += 2;
+   for (i = 0; i < (nverts * 3); i += 3) {
+      glTexCoord2f(tcoords[tIndex], tcoords[tIndex + 1]);
+      tIndex += 2;
 
       glVertex2f(verts[i], verts[i + 1]);
-	}
-	glEnd();
-	glPopMatrix();
+   }
+   glEnd();
+   glPopMatrix();
 
    glBindTexture(GL_TEXTURE_2D, 0);
    glEnable(GL_DEPTH_TEST);
@@ -1452,7 +1452,7 @@ void RFont_render_text(RFont_texture atlas, float* verts, float* tcoords, size_t
    }
 
    glBindTexture(GL_TEXTURE_2D, 0);
-	glDisable(GL_TEXTURE_2D);
+   glDisable(GL_TEXTURE_2D);
    glEnable(GL_DEPTH_TEST);
 }
 

--- a/RSGL.h
+++ b/RSGL.h
@@ -24,7 +24,7 @@
 /*
     define args
     (MAKE SURE RSGL_IMPLEMENTATION is in exactly one header or you use -DRSGL_IMPLEMENTATION)
-	#define RSGL_IMPLEMENTATION - makes it so source code is included with header
+    #define RSGL_IMPLEMENTATION - makes it so source code is included with header
     
     #define RSGL_NO_TEXT - do not include text rendering functions
     #define RSGL_INIT_FONTS [number of fonts] - set how much room should be pre-allocated for fonts by fontstash
@@ -101,27 +101,27 @@ RSGL basicDraw types
 
 #ifndef RSGL_INT_DEFINED
     #define RSGL_INT_DEFINED
-	#if defined(_MSC_VER) || defined(__SYMBIAN32__)
-		typedef unsigned char 	u8;
-		typedef signed char		i8;
-		typedef unsigned short  u16;
-		typedef signed short 	i16;
-		typedef unsigned int 	u32;
-		typedef signed int		i32;
-		typedef unsigned long	u64;
-		typedef signed long		i64;
-	#else
-		#include <stdint.h>
+    #if defined(_MSC_VER) || defined(__SYMBIAN32__)
+        typedef unsigned char   u8;
+        typedef signed char     i8;
+        typedef unsigned short  u16;
+        typedef signed short    i16;
+        typedef unsigned int    u32;
+        typedef signed int      i32;
+        typedef unsigned long   u64;
+        typedef signed long     i64;
+    #else
+        #include <stdint.h>
 
-		typedef uint8_t     u8;
-		typedef int8_t      i8;
-		typedef uint16_t   u16;
-		typedef int16_t    i16;
-		typedef uint32_t   u32;
-		typedef int32_t    i32;
-		typedef uint64_t   u64;
-		typedef int64_t    i64;
-	#endif
+        typedef uint8_t     u8;
+        typedef int8_t      i8;
+        typedef uint16_t   u16;
+        typedef int16_t    i16;
+        typedef uint32_t   u32;
+        typedef int32_t    i32;
+        typedef uint64_t   u64;
+        typedef int64_t    i64;
+    #endif
 #endif
 
 #ifndef RSGL_BOOL_DEFINED
@@ -291,17 +291,17 @@ typedef struct RSGL_RENDER_INFO {
 
 /* used internally for RSGL_deleteProgram */
 typedef enum RSGL_shaderType {
-	RSGL_shaderTypeNone = 0,
-	RSGL_shaderTypeStandard = 1, /* standard vertex+fragment shader */
-	RSGL_shaderTypeCompute = 2,
-	RSGL_shaderTypeGeometry = 4, /* unimplemented as of now */
+    RSGL_shaderTypeNone = 0,
+    RSGL_shaderTypeStandard = 1, /* standard vertex+fragment shader */
+    RSGL_shaderTypeCompute = 2,
+    RSGL_shaderTypeGeometry = 4, /* unimplemented as of now */
 } RSGL_shaderType;
 
 /* custom shader program */
 #ifndef RSGL_programInfo
 typedef struct RSGL_programInfo {
     u32 program;
-	 RSGL_shaderType type;
+     RSGL_shaderType type;
 } RSGL_programInfo;
 #endif
 
@@ -324,9 +324,9 @@ typedef struct RSGL_renderer {
     void (* bitmapToAtlas)(RSGL_texture atlas, u8* bitmap, float x, float y, float w, float h);
 
 #ifdef RSGL_USE_COMPUTE
-	 RSGL_programInfo (*createComputeProgram)(const char* CShaderCode);
-	 void (*dispatchComputeProgram)(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z);
-	 void (*bindComputeTexture)(u32 texture, u8 format);
+     RSGL_programInfo (*createComputeProgram)(const char* CShaderCode);
+     void (*dispatchComputeProgram)(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z);
+     void (*bindComputeTexture)(u32 texture, u8 format);
 #endif
 } RSGL_renderer;
 
@@ -556,10 +556,10 @@ RSGLDEF RSGL_area RSGL_textLineArea(const char* text, u32 fontSize, size_t textE
     #define M_PI 3.14159265358979323846f
 #endif
 #ifndef DEG2RAD
-    #define DEG2RAD (M_PI / 180.0f)
+    #define DEG2RAD (float)(M_PI / 180.0f)
 #endif
 #ifndef RAD2DEG
-    #define RAD2DEG (180.0f / M_PI)
+    #define RAD2DEG (float)(180.0f / M_PI)
 #endif
 
 #define RSGL_GET_MATRIX_X(x, y, z) (float)(matrix.m[0] * x + matrix.m[4] * y + matrix.m[8] * z + matrix.m[12])
@@ -727,15 +727,15 @@ void RSGL_renderSetShaderValue(u32 program, char* var, float value[], u8 len) {
 
 #ifdef RSGL_USE_COMPUTE
 RSGL_programInfo RSGL_renderCreateComputeProgram(const char* CShaderCode) {
-	return RSGL_currentRenderer.createComputeProgram(CShaderCode);
+    return RSGL_currentRenderer.createComputeProgram(CShaderCode);
 }
 
 void RSGL_renderDispatchComputeProgram(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z) {
-	RSGL_currentRenderer.dispatchComputeProgram(program, groups_x, groups_y, groups_z);
+    RSGL_currentRenderer.dispatchComputeProgram(program, groups_x, groups_y, groups_z);
 }
 
 void RSGL_renderBindComputeTexture(u32 texture, u8 format) {
-	RSGL_currentRenderer.bindComputeTexture(texture, format);
+    RSGL_currentRenderer.bindComputeTexture(texture, format);
 }
 #endif
 
@@ -1019,7 +1019,7 @@ void RSGL_drawArcF(RSGL_rectF o, RSGL_pointF arc, RSGL_color color) {
 void RSGL_drawCircleF(RSGL_circleF c, RSGL_color color) {  
     u32 verts = (u32)((2.0 * M_PI * c.d) / 10) % 360;
 
-    RSGL_drawPolygonFEx((RSGL_rectF){c.x, c.y, c.d, c.d}, verts, (RSGL_pointF){0, verts}, color); 
+    RSGL_drawPolygonFEx((RSGL_rectF){c.x, c.y, c.d, c.d}, verts, (RSGL_pointF){0.0f, (float)verts}, color); 
 }
 
 void RSGL_drawOvalF(RSGL_rectF o, RSGL_color c) { 
@@ -1040,7 +1040,7 @@ void RSGL_drawPoint3D(RSGL_point3D p, RSGL_color c) {
 void RSGL_drawLine3D(RSGL_point3D p1, RSGL_point3D p2, u32 thickness, RSGL_color c) {
     RSGL_args.lineWidth = thickness;
     
-    RSGL_point3D center = {(p1.x + p2.x) / 2.0f, (p1.y + p2.y) / 2.0f, (p1.z + p2.z) / 2.0};
+    RSGL_point3D center = {(p1.x + p2.x) / 2.0f, (p1.y + p2.y) / 2.0f, (p1.z + p2.z) / 2.0f};
     RSGL_mat4 matrix = RSGL_initDrawMatrix(center);
 
     float points[] = {RSGL_GET_MATRIX_POINT(p1.x, p1.y, p1.z), RSGL_GET_MATRIX_POINT(p2.x, p2.y, p2.z)};
@@ -1373,17 +1373,17 @@ RSGL_mat4 RSGL_ortho(float matrix[16], float left, float right, float bottom, fl
 
 /* Multiply the current matrix by a translation matrix */
 RSGL_mat4 RSGL_translate(float matrix[16], float x, float y, float z) {
-	RSGL_mat4 result;
+    RSGL_mat4 result;
 
-	for (int i = 0; i < 16; ++i) {
-		result.m[i] = matrix[i];
-	}
+    for (int i = 0; i < 16; ++i) {
+        result.m[i] = matrix[i];
+    }
 
-	result.m[12] += matrix[0]*x + matrix[4]*y + matrix[8]*z;
-	result.m[13] += matrix[1]*x + matrix[5]*y + matrix[9]*z;
-	result.m[14] += matrix[2]*x + matrix[6]*y + matrix[10]*z;
+    result.m[12] += matrix[0]*x + matrix[4]*y + matrix[8]*z;
+    result.m[13] += matrix[1]*x + matrix[5]*y + matrix[9]*z;
+    result.m[14] += matrix[2]*x + matrix[6]*y + matrix[10]*z;
 
-	return result;
+    return result;
 }
 
 /* Multiply the current matrix by a rotation matrix */
@@ -1421,28 +1421,28 @@ RSGL_mat4 RSGL_loadIdentity(void) {
 } 
 
 RSGL_mat4 RSGL_rotate(float matrix[16], float angle, float x, float y, float z) {
-	/* Axis vector (x, y, z) normalization */
-	float lengthSquared = x * x + y * y + z * z;
-	if ((lengthSquared != 1.0f) && (lengthSquared != 0.0f)) {
-		float inverseLength = 1.0f / sqrtf(lengthSquared);
-		x *= inverseLength;
-		y *= inverseLength;
-		z *= inverseLength;
-	}
+    /* Axis vector (x, y, z) normalization */
+    float lengthSquared = x * x + y * y + z * z;
+    if ((lengthSquared != 1.0f) && (lengthSquared != 0.0f)) {
+        float inverseLength = 1.0f / sqrtf(lengthSquared);
+        x *= inverseLength;
+        y *= inverseLength;
+        z *= inverseLength;
+    }
 
-	/* Rotation matrix generation */
-	float sinres = RSGL_SIN(angle);
-	float cosres = RSGL_COS(angle);
-	float t = 1.0f - cosres;
+    /* Rotation matrix generation */
+    float sinres = RSGL_SIN(angle);
+    float cosres = RSGL_COS(angle);
+    float t = 1.0f - cosres;
 
-	float matRotation[16] =  {
-            x * x * t + cosres,   	  	y * x * t + z * sinres,   	z * x * t - y * sinres,   	0.0f,
-            x * y * t - z * sinres,   	y * y * t + cosres,   		z * y * t + x * sinres,   	0.0f,
-            x * z * t + y * sinres,   	y * z * t - x * sinres,  	z * z * t + cosres,   		0.0f,
-            0.0f,   					0.0f,   					0.0f,   					1.0f
-	};
+    float matRotation[16] =  {
+            x * x * t + cosres,         y * x * t + z * sinres,     z * x * t - y * sinres,     0.0f,
+            x * y * t - z * sinres,     y * y * t + cosres,         z * y * t + x * sinres,     0.0f,
+            x * z * t + y * sinres,     y * z * t - x * sinres,     z * z * t + cosres,         0.0f,
+            0.0f,                       0.0f,                       0.0f,                       1.0f
+    };
 
-	return RSGL_mat4Multiply(matRotation, matrix);
+    return RSGL_mat4Multiply(matRotation, matrix);
 }
 
 RSGL_mat4 RSGL_perspective(float matrix[16], float fovY, float aspect, float zNear, float zFar) {
@@ -1453,10 +1453,10 @@ RSGL_mat4 RSGL_perspective(float matrix[16], float fovY, float aspect, float zNe
             (f / aspect), 0.0f,  0.0f,                                   0.0f,
             0,            f,     0.0f,                                   0.0f,
             0.0f,         0.0f,  (zFar + zNear) / (zNear - zFar),       -1.0f,
-            0.0f,         0.0f,  (2.0 * zFar * zNear) / (zNear - zFar),  0.0f
+            0.0f,         0.0f,  (2.0f * zFar * zNear) / (zNear - zFar),  0.0f
     };
     
-	return RSGL_mat4Multiply(matrix, perspective);
+    return RSGL_mat4Multiply(matrix, perspective);
 }
 
 RSGL_mat4 RSGL_mat4Multiply(float left[16], float right[16]) {

--- a/RSGL.h
+++ b/RSGL.h
@@ -24,7 +24,7 @@
 /*
     define args
     (MAKE SURE RSGL_IMPLEMENTATION is in exactly one header or you use -DRSGL_IMPLEMENTATION)
-    #define RSGL_IMPLEMENTATION - makes it so source code is included with header
+	#define RSGL_IMPLEMENTATION - makes it so source code is included with header
     
     #define RSGL_NO_TEXT - do not include text rendering functions
     #define RSGL_INIT_FONTS [number of fonts] - set how much room should be pre-allocated for fonts by fontstash
@@ -101,27 +101,27 @@ RSGL basicDraw types
 
 #ifndef RSGL_INT_DEFINED
     #define RSGL_INT_DEFINED
-    #if defined(_MSC_VER) || defined(__SYMBIAN32__)
-        typedef unsigned char   u8;
-        typedef signed char     i8;
-        typedef unsigned short  u16;
-        typedef signed short    i16;
-        typedef unsigned int    u32;
-        typedef signed int      i32;
-        typedef unsigned long   u64;
-        typedef signed long     i64;
-    #else
-        #include <stdint.h>
+	#if defined(_MSC_VER) || defined(__SYMBIAN32__)
+		typedef unsigned char 	u8;
+		typedef signed char		i8;
+		typedef unsigned short  u16;
+		typedef signed short 	i16;
+		typedef unsigned int 	u32;
+		typedef signed int		i32;
+		typedef unsigned long	u64;
+		typedef signed long		i64;
+	#else
+		#include <stdint.h>
 
-        typedef uint8_t     u8;
-        typedef int8_t      i8;
-        typedef uint16_t   u16;
-        typedef int16_t    i16;
-        typedef uint32_t   u32;
-        typedef int32_t    i32;
-        typedef uint64_t   u64;
-        typedef int64_t    i64;
-    #endif
+		typedef uint8_t     u8;
+		typedef int8_t      i8;
+		typedef uint16_t   u16;
+		typedef int16_t    i16;
+		typedef uint32_t   u32;
+		typedef int32_t    i32;
+		typedef uint64_t   u64;
+		typedef int64_t    i64;
+	#endif
 #endif
 
 #ifndef RSGL_BOOL_DEFINED
@@ -291,17 +291,17 @@ typedef struct RSGL_RENDER_INFO {
 
 /* used internally for RSGL_deleteProgram */
 typedef enum RSGL_shaderType {
-    RSGL_shaderTypeNone = 0,
-    RSGL_shaderTypeStandard = 1, /* standard vertex+fragment shader */
-    RSGL_shaderTypeCompute = 2,
-    RSGL_shaderTypeGeometry = 4, /* unimplemented as of now */
+	RSGL_shaderTypeNone = 0,
+	RSGL_shaderTypeStandard = 1, /* standard vertex+fragment shader */
+	RSGL_shaderTypeCompute = 2,
+	RSGL_shaderTypeGeometry = 4, /* unimplemented as of now */
 } RSGL_shaderType;
 
 /* custom shader program */
 #ifndef RSGL_programInfo
 typedef struct RSGL_programInfo {
     u32 program;
-     RSGL_shaderType type;
+	 RSGL_shaderType type;
 } RSGL_programInfo;
 #endif
 
@@ -324,9 +324,9 @@ typedef struct RSGL_renderer {
     void (* bitmapToAtlas)(RSGL_texture atlas, u8* bitmap, float x, float y, float w, float h);
 
 #ifdef RSGL_USE_COMPUTE
-     RSGL_programInfo (*createComputeProgram)(const char* CShaderCode);
-     void (*dispatchComputeProgram)(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z);
-     void (*bindComputeTexture)(u32 texture, u8 format);
+	 RSGL_programInfo (*createComputeProgram)(const char* CShaderCode);
+	 void (*dispatchComputeProgram)(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z);
+	 void (*bindComputeTexture)(u32 texture, u8 format);
 #endif
 } RSGL_renderer;
 
@@ -727,15 +727,15 @@ void RSGL_renderSetShaderValue(u32 program, char* var, float value[], u8 len) {
 
 #ifdef RSGL_USE_COMPUTE
 RSGL_programInfo RSGL_renderCreateComputeProgram(const char* CShaderCode) {
-    return RSGL_currentRenderer.createComputeProgram(CShaderCode);
+	return RSGL_currentRenderer.createComputeProgram(CShaderCode);
 }
 
 void RSGL_renderDispatchComputeProgram(RSGL_programInfo program, u32 groups_x, u32 groups_y, u32 groups_z) {
-    RSGL_currentRenderer.dispatchComputeProgram(program, groups_x, groups_y, groups_z);
+	RSGL_currentRenderer.dispatchComputeProgram(program, groups_x, groups_y, groups_z);
 }
 
 void RSGL_renderBindComputeTexture(u32 texture, u8 format) {
-    RSGL_currentRenderer.bindComputeTexture(texture, format);
+	RSGL_currentRenderer.bindComputeTexture(texture, format);
 }
 #endif
 
@@ -1019,7 +1019,7 @@ void RSGL_drawArcF(RSGL_rectF o, RSGL_pointF arc, RSGL_color color) {
 void RSGL_drawCircleF(RSGL_circleF c, RSGL_color color) {  
     u32 verts = (u32)((2.0 * M_PI * c.d) / 10) % 360;
 
-    RSGL_drawPolygonFEx((RSGL_rectF){c.x, c.y, c.d, c.d}, verts, (RSGL_pointF){0.0f, (float)verts}, color); 
+    RSGL_drawPolygonFEx((RSGL_rectF){c.x, c.y, c.d, c.d}, verts, (RSGL_pointF){0, (float)verts}, color); 
 }
 
 void RSGL_drawOvalF(RSGL_rectF o, RSGL_color c) { 
@@ -1373,17 +1373,17 @@ RSGL_mat4 RSGL_ortho(float matrix[16], float left, float right, float bottom, fl
 
 /* Multiply the current matrix by a translation matrix */
 RSGL_mat4 RSGL_translate(float matrix[16], float x, float y, float z) {
-    RSGL_mat4 result;
+	RSGL_mat4 result;
 
-    for (int i = 0; i < 16; ++i) {
-        result.m[i] = matrix[i];
-    }
+	for (int i = 0; i < 16; ++i) {
+		result.m[i] = matrix[i];
+	}
 
-    result.m[12] += matrix[0]*x + matrix[4]*y + matrix[8]*z;
-    result.m[13] += matrix[1]*x + matrix[5]*y + matrix[9]*z;
-    result.m[14] += matrix[2]*x + matrix[6]*y + matrix[10]*z;
+	result.m[12] += matrix[0]*x + matrix[4]*y + matrix[8]*z;
+	result.m[13] += matrix[1]*x + matrix[5]*y + matrix[9]*z;
+	result.m[14] += matrix[2]*x + matrix[6]*y + matrix[10]*z;
 
-    return result;
+	return result;
 }
 
 /* Multiply the current matrix by a rotation matrix */
@@ -1421,28 +1421,28 @@ RSGL_mat4 RSGL_loadIdentity(void) {
 } 
 
 RSGL_mat4 RSGL_rotate(float matrix[16], float angle, float x, float y, float z) {
-    /* Axis vector (x, y, z) normalization */
-    float lengthSquared = x * x + y * y + z * z;
-    if ((lengthSquared != 1.0f) && (lengthSquared != 0.0f)) {
-        float inverseLength = 1.0f / sqrtf(lengthSquared);
-        x *= inverseLength;
-        y *= inverseLength;
-        z *= inverseLength;
-    }
+	/* Axis vector (x, y, z) normalization */
+	float lengthSquared = x * x + y * y + z * z;
+	if ((lengthSquared != 1.0f) && (lengthSquared != 0.0f)) {
+		float inverseLength = 1.0f / sqrtf(lengthSquared);
+		x *= inverseLength;
+		y *= inverseLength;
+		z *= inverseLength;
+	}
 
-    /* Rotation matrix generation */
-    float sinres = RSGL_SIN(angle);
-    float cosres = RSGL_COS(angle);
-    float t = 1.0f - cosres;
+	/* Rotation matrix generation */
+	float sinres = RSGL_SIN(angle);
+	float cosres = RSGL_COS(angle);
+	float t = 1.0f - cosres;
 
-    float matRotation[16] =  {
-            x * x * t + cosres,         y * x * t + z * sinres,     z * x * t - y * sinres,     0.0f,
-            x * y * t - z * sinres,     y * y * t + cosres,         z * y * t + x * sinres,     0.0f,
-            x * z * t + y * sinres,     y * z * t - x * sinres,     z * z * t + cosres,         0.0f,
-            0.0f,                       0.0f,                       0.0f,                       1.0f
-    };
+	float matRotation[16] =  {
+            x * x * t + cosres,   	  	y * x * t + z * sinres,   	z * x * t - y * sinres,   	0.0f,
+            x * y * t - z * sinres,   	y * y * t + cosres,   		z * y * t + x * sinres,   	0.0f,
+            x * z * t + y * sinres,   	y * z * t - x * sinres,  	z * z * t + cosres,   		0.0f,
+            0.0f,   					0.0f,   					0.0f,   					1.0f
+	};
 
-    return RSGL_mat4Multiply(matRotation, matrix);
+	return RSGL_mat4Multiply(matRotation, matrix);
 }
 
 RSGL_mat4 RSGL_perspective(float matrix[16], float fovY, float aspect, float zNear, float zFar) {
@@ -1456,7 +1456,7 @@ RSGL_mat4 RSGL_perspective(float matrix[16], float fovY, float aspect, float zNe
             0.0f,         0.0f,  (2.0f * zFar * zNear) / (zNear - zFar),  0.0f
     };
     
-    return RSGL_mat4Multiply(matrix, perspective);
+	return RSGL_mat4Multiply(matrix, perspective);
 }
 
 RSGL_mat4 RSGL_mat4Multiply(float left[16], float right[16]) {


### PR DESCRIPTION
I got a bunch of warnings like below:

```
RSGL.h:1456:55: warning: narrowing conversion of ‘(((2.0e+0 * ((double)zFar)) * ((double)zNear)) / ((double)(zNear - zFar)))’ from ‘double’ to ‘float’ [-Wnarrowing]
 1456 |             0.0f,         0.0f,  (2.0 * zFar * zNear) / (zNear - zFar),  0.0f
```

doing the explicit cast has the same result but no warnings