### PR TITLE
removed second scissor

### DIFF
--- a/RSGL_gl.h
+++ b/RSGL_gl.h
@@ -638,7 +638,6 @@ void RSGL_GL_scissorStart(RSGL_rectF scissor) {
     glEnable(GL_SCISSOR_TEST);
 
     glScissor(scissor.x, RSGL_args.currentArea.h - (scissor.y + scissor.h), scissor.w, scissor.h);
-    glScissor(scissor.x, scissor.y, scissor.w, scissor.h);
 }
 
 void RSGL_GL_scissorEnd(void) {


### PR DESCRIPTION
Not sure why it's there. Certain other libraries don't have this second line. 

With it present: nothing is drawn in the scissor region
With it removed: everything renders correctly